### PR TITLE
update readme with demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
     An all-in-one business management webapp template
     <br />
     <br />
-    <a href="https://casa-a45k.onrender.com">View Demo</a>
+    <a href="https://casa-8uei.onrender.com">View Demo</a>
     ·
     <a href="https://github.com/casa-business-manager/CASA/issues/new/choose">Report Bug</a>
     ·
@@ -78,7 +78,7 @@ However, we hope that this project can serve as a solid starting point for any f
 * Email sending with a rich text editor and template selection
 * Customizable hierarchical roles system
 
-For more information about the state of the project, check out the <a href="https://casa-a45k.onrender.com">demo</a> or <a href="#screenshots">Screenshots</a> sections
+For more information about the state of the project, check out the <a href="https://casa-8uei.onrender.com">demo</a> or <a href="#screenshots">Screenshots</a> sections
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 


### PR DESCRIPTION
frontend is currently live at https://casa-a45k.onrender.com and the link is updated on the demo

still trying to get the backend demo up, but this link will not change once i get the demo up and running.